### PR TITLE
Removed 'website' folder from Categories

### DIFF
--- a/website/src/Categories.js
+++ b/website/src/Categories.js
@@ -12,7 +12,7 @@ export default function Categories(props) {
 		axios.get('https://api.github.com/repos/skully-coder/competitiveprogramming/contents')
 		.then(response => {
 			response.data.forEach(content => {
-				if(!content.name.startsWith('.') && content.type === "dir") {
+				if(content.name !== "website" && !content.name.startsWith('.') && content.type === "dir") {
 					setCategories(categories => categories.concat({ name: content.name, url: content.git_url }))
 				}
 			})


### PR DESCRIPTION
<!-- make sure that these checkboxes are checked in order -->
# Description

Fixed "website" folder being displayed in the "Categories" pages on Dashboard

Fixes #227 

## Type of change
<!-- to check the box, type 'X' in the square brackets, for example [X] README.md -->
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
